### PR TITLE
[Feat] 플레이리스트 생성 시 첫 번째 곡 썸네일 및 곡 추가 기능 구현

### DIFF
--- a/src/playlist/dto/create-playlist.dto.ts
+++ b/src/playlist/dto/create-playlist.dto.ts
@@ -1,5 +1,7 @@
-import { IsString, IsOptional, IsArray } from 'class-validator';
+import { IsString, IsOptional, IsArray, ValidateNested } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { AddVideoDto } from './add-video.dto';
+import { Type } from 'class-transformer';
 
 export class CreatePlaylistDto {
   @ApiProperty({
@@ -27,4 +29,12 @@ export class CreatePlaylistDto {
   @IsString({ each: true })
   @IsOptional()
   tags?: string[];
+
+  @ApiProperty({
+    description: '플레이리스트에 추가할 첫 번째 곡 정보',
+    type: AddVideoDto,
+  })
+  @ValidateNested()
+  @Type(() => AddVideoDto)
+  firstVideo: AddVideoDto;
 }

--- a/src/playlist/dto/create-playlist.dto.ts
+++ b/src/playlist/dto/create-playlist.dto.ts
@@ -1,7 +1,6 @@
 import { IsString, IsOptional, IsArray, ValidateNested } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
-import { AddVideoDto } from './add-video.dto';
-import { Type } from 'class-transformer';
+
 
 export class CreatePlaylistDto {
   @ApiProperty({
@@ -12,7 +11,7 @@ export class CreatePlaylistDto {
   title: string;
 
   @ApiProperty({
-    example: '즐겨듣는 노래들을 모았습니다.',
+    example: '즐겨듣는 노래 모음',
     description: '플레이리스트 설명',
     required: false,
   })
@@ -29,12 +28,4 @@ export class CreatePlaylistDto {
   @IsString({ each: true })
   @IsOptional()
   tags?: string[];
-
-  @ApiProperty({
-    description: '플레이리스트에 추가할 첫 번째 곡 정보',
-    type: AddVideoDto,
-  })
-  @ValidateNested()
-  @Type(() => AddVideoDto)
-  firstVideo: AddVideoDto;
 }

--- a/src/playlist/playlist.controller.ts
+++ b/src/playlist/playlist.controller.ts
@@ -144,12 +144,14 @@ export class PlaylistController {
         id: 1,
         title: 'My Playlist',
         description: '공부할 때 듣기 좋은 음악',
+        coverImage: 'https://img.youtube.com/vi/example/0.jpg',
         tags: ['공부', '집중'],
         videos: [
           {
             id: 101,
             title: '노래 제목',
             url: 'https://youtube.com/watch?v=example',
+            thumbnailUrl: 'https://img.youtube.com/vi/example/0.jpg',
           },
         ],
       },
@@ -167,7 +169,6 @@ export class PlaylistController {
   })  
   async getPlaylistDetails(@Param('id') id: string): Promise<any> {
     const playlist = await this.playlistService.getPlaylistDetails(parseInt(id, 10));
-
     return playlist;
   }
     
@@ -176,27 +177,18 @@ export class PlaylistController {
   @UseGuards(JwtAuthGuard)
   @ApiOperation({
     summary: '플레이리스트 생성',
-    description: `새로운 플레이리스트를 생성하고 첫 번째 곡을 동시에 추가합니다.
-                  첫 번째 곡의 썸네일이 플레이리스트의 커버 이미지로 설정됩니다.`,
+    description: `새로운 플레이리스트를 생성합니다.`,
   })
   @ApiResponse({
     status: 201,
-    description: '플레이리스트 생성 및 첫 번째 곡 추가 성공',
+    description: '플레이리스트 생성 성공',
     schema: {
       example: {
         id: 1,
         title: 'My Favorite Songs',
         description: '즐겨듣는 노래 모음',
-        coverImage: 'https://example.com/thumbnail.jpg',
         tags: ['Pop', 'K-Pop'],
-        videos: [
-          {
-            id: 101,
-            title: 'My Song',
-            url: 'https://youtube.com/watch?v=abc123',
-          },
-        ],
-        message: '플레이리스트 생성 및 첫 번째 곡 추가 성공',
+        message: '플레이리스트 생성 성공',
       },
     },
   })
@@ -361,8 +353,9 @@ export class PlaylistController {
       example: {
         playlistId: 1,
         videoId: 101,
-        title: '노래 제목',
-        url: 'https://youtube.com/watch?v=example',
+        title: 'aespa 에스파 Whiplash MV',
+        url: 'https://youtube.com/watch?v=jWQx2f-CErU',
+        thumbnailUrl: 'https://img.youtube.com/vi/jWQx2f-CErU/0.jpg',
         message: '곡 추가 성공',
         order: 1,
       },
@@ -395,6 +388,7 @@ export class PlaylistController {
       videoId: video.id,
       title: video.title,
       url: `https://youtube.com/watch?v=${video.youtubeId}`,
+      thumbnailUrl: video.thumbnailUrl,
       message: '곡 추가 성공',
       order: video.order,
     };

--- a/src/playlist/playlist.controller.ts
+++ b/src/playlist/playlist.controller.ts
@@ -174,24 +174,36 @@ export class PlaylistController {
 
   @Post()
   @UseGuards(JwtAuthGuard)
-  @ApiOperation({ summary: '플레이리스트 생성', description: '새로운 플레이리스트를 생성합니다.' })
+  @ApiOperation({
+    summary: '플레이리스트 생성',
+    description: `새로운 플레이리스트를 생성하고 첫 번째 곡을 동시에 추가합니다.
+                  첫 번째 곡의 썸네일이 플레이리스트의 커버 이미지로 설정됩니다.`,
+  })
   @ApiResponse({
     status: 201,
-    description: '플레이리스트 생성 성공',
+    description: '플레이리스트 생성 및 첫 번째 곡 추가 성공',
     schema: {
       example: {
         id: 1,
-        title: 'My Playlist',
-        description: '공부할 때 듣기 좋은 음악',
-        tags: ['공부', '집중'],
-        message: '플레이리스트 생성 성공',
+        title: 'My Favorite Songs',
+        description: '즐겨듣는 노래 모음',
+        coverImage: 'https://example.com/thumbnail.jpg',
+        tags: ['Pop', 'K-Pop'],
+        videos: [
+          {
+            id: 101,
+            title: 'My Song',
+            url: 'https://youtube.com/watch?v=abc123',
+          },
+        ],
+        message: '플레이리스트 생성 및 첫 번째 곡 추가 성공',
       },
     },
   })
   @ApiResponse({
     status: 400,
     description: '필수 데이터 누락',
-    schema: { example: { message: '제목과 태그는 필수입니다.' } },
+    schema: { example: { message: '제목과 태그, 첫번째 비디오 값은 필수입니다.' } },
   })
   @ApiResponse({
     status: 401,
@@ -201,14 +213,7 @@ export class PlaylistController {
   async createPlaylist(@Body() dto: CreatePlaylistDto, @Req() req): Promise<any> {
     const userId = req.user?.userId;
     const playlist = await this.playlistService.createPlaylist(dto, userId);
-  
-    return {
-      id: playlist.id,
-      title: playlist.title,
-      description: playlist.description,
-      tags: playlist.tags, // 안전하게 반환
-      message: '플레이리스트 생성 성공',
-    };
+    return playlist;
   }
   
   


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)


- ✨ **유튜브 검색 및 곡 추가**  
   - [x] 유튜브 검색 결과 중 원하는 곡을 선택하여 플레이리스트에 동시에 추가.
   - [x] 플레이리스트의 첫 번째 곡의 `thumbnailUrl`을 `coverImage`로 자동 설정.  

- 🎉 **플레이리스트 생성**  
   - [x] `title`, `tags`를 입력받아 플레이리스트를 생성.  
   - [x] 선택된 곡의 정보를 함께 저장하며 플레이리스트와 곡이 동시에 등록.  

---

# 🤔 논의가 필요한 사항 (Points to discuss)

- [ ] 플레이리스트 생성 흐름이 맞는지 논의!
- [ ] 플레이리스트 순서 정렬 수정하려고 API 테스트 -> 잘 작동하길래 이미지 첨부했습니다! 검토 부탁드려요!!
---

# 🖼️ 결과 이미지 (Screenshots)

| **플레이리스트 생성 결과**              | **플레이리스트 조회 결과(순서 변경한 상태)**     |
|----------------------------------|--------------------------------|
| 플레이리스트 생성(첫번째 곡 바로 추가)![image](https://github.com/user-attachments/assets/13d0ee94-1ddc-4c5d-a3ae-05292f1de518)           | 플레이리스트 조회(순서 변경한 상태)![image](https://github.com/user-attachments/assets/605e1383-8745-4163-aaab-b297fdf95c1d) | 
---

# 🛠️ 추가 수정 필요 사항 (Additional fixes required)

<!-- PR에 포함되지 않았지만, 추가적으로 해야 할 작업이 있다면 작성해주세요. -->
- [ ] API 요청 시 유튜브 곡 선택 최적화  

---

# 📝 참고 사항 (Additional notes)

<!-- 테스트 방법, 관련 이슈, 참고 문서 등을 작성해주세요. -->
- **테스트 방법**:  
   1. Swagger UI 확인: `http://localhost:2222/api-docs`
- **참고 자료**: [유튜브 API 문서](https://developers.google.com/youtube)  
