### PR TITLE
플레이리스트 비디오 추가 및 상세 조회 API 개선

### DIFF
--- a/src/playlist/dto/create-playlist.dto.ts
+++ b/src/playlist/dto/create-playlist.dto.ts
@@ -1,5 +1,7 @@
-import { IsString, IsOptional, IsArray } from 'class-validator';
+import { IsString, IsOptional, IsArray, ValidateNested } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { AddVideoDto } from './add-video.dto';
+import { Type } from 'class-transformer';
 
 export class CreatePlaylistDto {
   @ApiProperty({
@@ -27,4 +29,12 @@ export class CreatePlaylistDto {
   @IsString({ each: true })
   @IsOptional()
   tags?: string[];
+
+  @ApiProperty({
+    description: '플레이리스트에 추가할 첫 번째 곡 정보',
+    type: AddVideoDto,
+  })
+  @ValidateNested()
+  @Type(() => AddVideoDto)
+  firstVideo: AddVideoDto;
 }

--- a/src/playlist/dto/create-playlist.dto.ts
+++ b/src/playlist/dto/create-playlist.dto.ts
@@ -1,7 +1,6 @@
 import { IsString, IsOptional, IsArray, ValidateNested } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
-import { AddVideoDto } from './add-video.dto';
-import { Type } from 'class-transformer';
+
 
 export class CreatePlaylistDto {
   @ApiProperty({
@@ -12,7 +11,7 @@ export class CreatePlaylistDto {
   title: string;
 
   @ApiProperty({
-    example: '즐겨듣는 노래들을 모았습니다.',
+    example: '즐겨듣는 노래 모음',
     description: '플레이리스트 설명',
     required: false,
   })
@@ -29,12 +28,4 @@ export class CreatePlaylistDto {
   @IsString({ each: true })
   @IsOptional()
   tags?: string[];
-
-  @ApiProperty({
-    description: '플레이리스트에 추가할 첫 번째 곡 정보',
-    type: AddVideoDto,
-  })
-  @ValidateNested()
-  @Type(() => AddVideoDto)
-  firstVideo: AddVideoDto;
 }

--- a/src/playlist/playlist.controller.ts
+++ b/src/playlist/playlist.controller.ts
@@ -144,12 +144,14 @@ export class PlaylistController {
         id: 1,
         title: 'My Playlist',
         description: '공부할 때 듣기 좋은 음악',
+        coverImage: 'https://img.youtube.com/vi/example/0.jpg',
         tags: ['공부', '집중'],
         videos: [
           {
             id: 101,
             title: '노래 제목',
             url: 'https://youtube.com/watch?v=example',
+            thumbnailUrl: 'https://img.youtube.com/vi/example/0.jpg',
           },
         ],
       },
@@ -167,7 +169,6 @@ export class PlaylistController {
   })  
   async getPlaylistDetails(@Param('id') id: string): Promise<any> {
     const playlist = await this.playlistService.getPlaylistDetails(parseInt(id, 10));
-
     return playlist;
   }
     
@@ -176,27 +177,18 @@ export class PlaylistController {
   @UseGuards(JwtAuthGuard)
   @ApiOperation({
     summary: '플레이리스트 생성',
-    description: `새로운 플레이리스트를 생성하고 첫 번째 곡을 동시에 추가합니다.
-                  첫 번째 곡의 썸네일이 플레이리스트의 커버 이미지로 설정됩니다.`,
+    description: `새로운 플레이리스트를 생성합니다.`,
   })
   @ApiResponse({
     status: 201,
-    description: '플레이리스트 생성 및 첫 번째 곡 추가 성공',
+    description: '플레이리스트 생성 성공',
     schema: {
       example: {
         id: 1,
         title: 'My Favorite Songs',
         description: '즐겨듣는 노래 모음',
-        coverImage: 'https://example.com/thumbnail.jpg',
         tags: ['Pop', 'K-Pop'],
-        videos: [
-          {
-            id: 101,
-            title: 'My Song',
-            url: 'https://youtube.com/watch?v=abc123',
-          },
-        ],
-        message: '플레이리스트 생성 및 첫 번째 곡 추가 성공',
+        message: '플레이리스트 생성 성공',
       },
     },
   })
@@ -361,8 +353,9 @@ export class PlaylistController {
       example: {
         playlistId: 1,
         videoId: 101,
-        title: '노래 제목',
-        url: 'https://youtube.com/watch?v=example',
+        title: 'aespa 에스파 Whiplash MV',
+        url: 'https://youtube.com/watch?v=jWQx2f-CErU',
+        thumbnailUrl: 'https://img.youtube.com/vi/jWQx2f-CErU/0.jpg',
         message: '곡 추가 성공',
         order: 1,
       },
@@ -395,6 +388,7 @@ export class PlaylistController {
       videoId: video.id,
       title: video.title,
       url: `https://youtube.com/watch?v=${video.youtubeId}`,
+      thumbnailUrl: video.thumbnailUrl,
       message: '곡 추가 성공',
       order: video.order,
     };

--- a/src/playlist/playlist.controller.ts
+++ b/src/playlist/playlist.controller.ts
@@ -343,10 +343,11 @@ export class PlaylistController {
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ 
     summary: '플레이리스트에 곡 추가', 
-    description: `기존 플레이리스트에 곡(비디오)를 추가합니다.
-                  동영상을 추가할 때 duration 필드는 선택 사항입니다.
-                  값을 제공하지 않아도 되며, 동영상의 길이(초 단위)를 입력하면 됩니다. 
-                  order 값은 기존 비디오 수를 기준으로 순서가 설정됩니다.(1로 두어도 알아서 늘어납니다.)` })
+    description: `기존 플레이리스트에 곡(비디오)를 추가합니다.<br>
+                  동영상을 추가할 때 duration 필드는 선택 사항입니다.<br>
+                  값을 제공하지 않아도 되며, 동영상의 길이(초 단위)를 입력하면 됩니다. <br>
+                  order 값은 기존 비디오 수를 기준으로 순서가 설정됩니다.<br>
+                  (1로 두어도 알아서 늘어납니다.)` })
   @ApiResponse({
     status: 201,
     description: '곡 추가 성공',

--- a/src/playlist/playlist.controller.ts
+++ b/src/playlist/playlist.controller.ts
@@ -345,7 +345,8 @@ export class PlaylistController {
     summary: '플레이리스트에 곡 추가', 
     description: `기존 플레이리스트에 곡(비디오)를 추가합니다.
                   동영상을 추가할 때 duration 필드는 선택 사항입니다.
-                  값을 제공하지 않아도 되며, 동영상의 길이(초 단위)를 입력하면 됩니다.` })
+                  값을 제공하지 않아도 되며, 동영상의 길이(초 단위)를 입력하면 됩니다. 
+                  order 값은 기존 비디오 수를 기준으로 순서가 설정됩니다.(1로 두어도 알아서 늘어납니다.)` })
   @ApiResponse({
     status: 201,
     description: '곡 추가 성공',

--- a/src/playlist/playlist.controller.ts
+++ b/src/playlist/playlist.controller.ts
@@ -174,24 +174,36 @@ export class PlaylistController {
 
   @Post()
   @UseGuards(JwtAuthGuard)
-  @ApiOperation({ summary: '플레이리스트 생성', description: '새로운 플레이리스트를 생성합니다.' })
+  @ApiOperation({
+    summary: '플레이리스트 생성',
+    description: `새로운 플레이리스트를 생성하고 첫 번째 곡을 동시에 추가합니다.
+                  첫 번째 곡의 썸네일이 플레이리스트의 커버 이미지로 설정됩니다.`,
+  })
   @ApiResponse({
     status: 201,
-    description: '플레이리스트 생성 성공',
+    description: '플레이리스트 생성 및 첫 번째 곡 추가 성공',
     schema: {
       example: {
         id: 1,
-        title: 'My Playlist',
-        description: '공부할 때 듣기 좋은 음악',
-        tags: ['공부', '집중'],
-        message: '플레이리스트 생성 성공',
+        title: 'My Favorite Songs',
+        description: '즐겨듣는 노래 모음',
+        coverImage: 'https://example.com/thumbnail.jpg',
+        tags: ['Pop', 'K-Pop'],
+        videos: [
+          {
+            id: 101,
+            title: 'My Song',
+            url: 'https://youtube.com/watch?v=abc123',
+          },
+        ],
+        message: '플레이리스트 생성 및 첫 번째 곡 추가 성공',
       },
     },
   })
   @ApiResponse({
     status: 400,
     description: '필수 데이터 누락',
-    schema: { example: { message: '제목과 태그는 필수입니다.' } },
+    schema: { example: { message: '제목과 태그, 첫번째 비디오 값은 필수입니다.' } },
   })
   @ApiResponse({
     status: 401,
@@ -201,14 +213,7 @@ export class PlaylistController {
   async createPlaylist(@Body() dto: CreatePlaylistDto, @Req() req): Promise<any> {
     const userId = req.user?.userId;
     const playlist = await this.playlistService.createPlaylist(dto, userId);
-  
-    return {
-      id: playlist.id,
-      title: playlist.title,
-      description: playlist.description,
-      tags: playlist.tags, // 안전하게 반환
-      message: '플레이리스트 생성 성공',
-    };
+    return playlist;
   }
   
   


### PR DESCRIPTION

이 PR은 닫힌 PR [#13 ](https://github.com/MyPli/backend/pull/13)를 대체하며, 수정 사항이 포함되었습니다.

# 🚀 구현한 내용 (What was implemented)
- ✨ **플레이리스트 비디오 추가 개선**
  - [x] 곡 추가 시, **맨 처음 추가된 비디오**의 썸네일을 `coverImage`로 설정하도록 로직 수정.
  - [x] `duration` 필드가 비어있을 경우, 유튜브 API를 통해 자동으로 가져오는 기능 유지.
  - [x] 곡 추가 API의 응답을 **추가된 비디오 정보(JSON 형식)** 로 반환하도록 수정.
  - [x] 비디오 추가할 때 순서 값이 자동으로 늘어나도록 수정.(`order: playlist.videos.length + 1`)

- ✨ **플레이리스트 상세 조회 개선**
  - [x] 플레이리스트 상세 조회 API 응답을 **요청된 JSON 형식**에 맞게 수정.
  - [x] 비디오 배열(`videos`)에 각 비디오의 `id`, `title`, `url`, `thumbnailUrl`을 포함하도록 응답 구조 변경.

---

# 🤔 논의가 필요한 사항 (Points to discuss)
- [ ] API 응답 형식이 프론트엔드 요구 사항과 **완전히 일치**하는지 확인.

---

# 🖼️ 결과 이미지 (Screenshots)
| **플레이리스트 상세 조회**     | **플레이리스트 곡 추가**       | **인기 플레이리스트 반환**       | 
|-----------------------------|-----------------------------|-----------------------------|
| ![image](https://github.com/user-attachments/assets/65382d75-54d1-4636-ba64-1cecca1ff56c)    | ![image](https://github.com/user-attachments/assets/2735eea6-ec43-460e-9026-1064facc72c4)     | ![image](https://github.com/user-attachments/assets/fbe67ded-c5b1-4a83-a652-020f562e85f6)      | 

 |**최신 플레이리스트 반환**       | **내 플레이리스트 반환**       | **플레이리스트 생성**        | 
 |-----------------------------|-----------------------------|-----------------------------|
|![image](https://github.com/user-attachments/assets/3594c20a-8988-404b-ad59-28b64f5a8faf)     | ![image](https://github.com/user-attachments/assets/7b663ae6-dc6f-494e-839e-44e677af8d46)      | ![image](https://github.com/user-attachments/assets/5523c942-e587-49c0-a74d-3949d5ef620c)     |


---

# 🛠️ 추가 수정 필요 사항 (Additional fixes required)
- 구현 로직이 잘못됐을 경우 다시 수정하기!

---

# 📝 참고 사항 (Additional notes)
- **테스트 방법**:
  1. `POST api/playlists/:id/videos`를 호출하여 곡 추가 테스트.
  2. `GET api/playlists/:id`를 호출하여 상세 조회 결과 확인.
- **참고 자료**:
  - [유튜브 API 문서](https://developers.google.com/youtube/v3/docs)

