### PR TITLE
[Feat] GET /playlists/{id} API에 totalTime, time, artist, createdBy 필드 추가

### DIFF
--- a/src/playlist/playlist.controller.ts
+++ b/src/playlist/playlist.controller.ts
@@ -146,12 +146,16 @@ export class PlaylistController {
         description: '공부할 때 듣기 좋은 음악',
         coverImage: 'https://img.youtube.com/vi/example/0.jpg',
         tags: ['공부', '집중'],
+        createdBy: "Jhon Doe",
+        totalTime: '01:25:30',
         videos: [
           {
             id: 101,
             title: '노래 제목',
             url: 'https://youtube.com/watch?v=example',
             thumbnailUrl: 'https://img.youtube.com/vi/example/0.jpg',
+            artist: 'SMTOWN',
+            time: '03:45',
           },
         ],
       },


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)

<!-- 구현한 기능이나 변경 사항을 간략히 요약해주세요. -->
- ✨ 주요 기능:
  - [x] `GET /playlists/{id}` API에 `totalTime` 필드 추가: 플레이리스트 내 비디오들의 총 시간을 계산하여 반환.
  - [x] `GET /playlists/{id}` API에 `artist`(= channelName) 및 `time`(포맷된 duration) 필드 추가.
  - [x] `GET /playlists/{id}` API에 생성자의 닉네임(`createdBy`) 필드 추가.

---

# 🤔 논의가 필요한 사항 (Points to discuss)

<!-- 논의가 필요한 사항, 개선해야 할 부분을 작성해주세요. -->
- [ ] `totalTime`의 시간 포맷(`hh:mm:ss` vs `mm:ss`)에 대한 추가 논의 필요.

---

# 🖼️ 결과 이미지 (Screenshots)

<!-- 변경된 결과를 확인할 수 있는 스크린샷을 첨부해주세요. -->
| **GET /playlists/{id} 응답 예시**   |
|-----------------------------|
| ![image](https://github.com/user-attachments/assets/2d703f03-b0b0-4aac-87e1-3d7f278bae97) | 

---

# 🛠️ 추가 수정 필요 사항 (Additional fixes required)

<!-- PR에 포함되지 않았지만, 추가적으로 해야 할 작업이 있다면 작성해주세요. -->
- 수정 사항 들어오면 수정하기!

---

# 📝 참고 사항 (Additional notes)

<!-- 테스트 방법, 관련 이슈, 참고 문서 등을 작성해주세요. -->

- **테스트 방법**:
  1. `GET /playlists/{id}` 호출하여 응답 데이터에 `totalTime`, `time`, `artist`, `createdBy` 필드 확인.
