### PR TITLE
[Feat] GET /playlists/{id} API에 createdByMe, liked 필드 추가

### DIFF
--- a/src/playlist/playlist.controller.ts
+++ b/src/playlist/playlist.controller.ts
@@ -147,6 +147,8 @@ export class PlaylistController {
         coverImage: 'https://img.youtube.com/vi/example/0.jpg',
         tags: ['공부', '집중'],
         createdBy: "Jhon Doe",
+        createdByMe: true, // 내가 만든 플레이리스트 여부
+        liked: true, // 좋아요 여부
         totalTime: '01:25:30',
         videos: [
           {
@@ -170,9 +172,10 @@ export class PlaylistController {
     status: 401,
     description: '인증 오류',
     schema: { example: { message: '인증이 필요합니다.' } },
-  })  
-  async getPlaylistDetails(@Param('id') id: string): Promise<any> {
-    const playlist = await this.playlistService.getPlaylistDetails(parseInt(id, 10));
+  })
+  async getPlaylistDetails(@Param('id') id: string, @Req() req: Request): Promise<any> {
+    const userId = req.user.userId; // 인증된 사용자의 ID 가져오기
+    const playlist = await this.playlistService.getPlaylistDetails(parseInt(id, 10), userId);
     return playlist;
   }
     

--- a/src/playlist/playlist.service.ts
+++ b/src/playlist/playlist.service.ts
@@ -184,11 +184,11 @@ export class PlaylistService {
   
 
   // 5. 플레이리스트 상세 조회
-  async getPlaylistDetails(id: number): Promise<any> {
+  async getPlaylistDetails(id: number, userId: number): Promise<any> {
     const playlist = await this.prisma.playlist.findUnique({
       where: { id },
       include: {
-        user: { select: { nickname: true } }, // 닉네임 가져오기
+        user: { select: { nickname: true, id: true } }, // 닉네임과 사용자 ID 가져오기
         tags: { include: { tag: { select: { name: true } } } }, // 태그 이름 가져오기
         videos: {
           select: {
@@ -198,6 +198,11 @@ export class PlaylistService {
             thumbnailUrl: true,
             duration: true, // 비디오 길이
             channelName: true, // 아티스트로 사용할 채널 이름
+          },
+        },
+        likes: {
+          select: {
+            userId: true, // 좋아요를 누른 사용자 ID 가져오기
           },
         },
       },
@@ -230,6 +235,8 @@ export class PlaylistService {
       coverImage: playlist.coverImage || null,
       tags: playlist.tags.map((tag) => tag.tag.name),
       createdBy: playlist.user?.nickname || 'Unknown', // 닉네임 사용
+      createdByMe: playlist.user?.id === userId, // 내가 만든 플레이리스트인지 여부
+      liked: playlist.likes.some((like) => like.userId === userId), // 좋아요 여부
       totalTime: this.formatDuration(totalTime), // 포맷된 총 시간 반환
       videos,
     };


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)

<!-- 구현한 기능이나 변경 사항을 간략히 요약해주세요. -->
- ✨ 주요 기능:
  - [x] 플레이리스트 상세 조회 API에 `createdByMe` 필드 추가: 현재 사용자가 해당 플레이리스트를 생성했는지 여부 반환.
  - [x] 플레이리스트 상세 조회 API에 `liked` 필드 추가: 현재 사용자가 해당 플레이리스트를 좋아요 했는지 여부를 boolean으로 반환.
  - [x] 기존 `likesCount` 필드를 boolean 필드 `liked`로 대체하여 프론트엔드 요구사항 반영.

---

# 🤔 논의가 필요한 사항 (Points to discuss)

<!-- 논의가 필요한 사항, 개선해야 할 부분을 작성해주세요. -->
- [ ] `liked` 필드 반환 방식이 현재 사용자의 상태에 의존하므로, 다른 API 호출에서도 이와 유사한 접근 방식을 적용할 필요가 있는지.

---

# 🖼️ 결과 이미지 (Screenshots)

<!-- 변경된 결과를 확인할 수 있는 스크린샷을 첨부해주세요. -->
| **플레이리스트 상세조회 응답**                  | **플레이리스트 상세조회 응답 예시**                  |
|-----------------------------|-----------------------------|
| ![image](https://github.com/user-attachments/assets/ead5dd49-9e1c-480e-91fd-eebaf5b24a47)    | ![image](https://github.com/user-attachments/assets/b166d350-758b-49d5-a09c-79d5e305cd9c)   |

---

# 🛠️ 추가 수정 필요 사항 (Additional fixes required)

<!-- PR에 포함되지 않았지만, 추가적으로 해야 할 작업이 있다면 작성해주세요. -->
- [ ] 사용자 상태에 기반한 API 응답이 다른 API에서도 필요한지 추가 논의.
---

# 📝 참고 사항 (Additional notes)

<!-- 테스트 방법, 관련 이슈, 참고 문서 등을 작성해주세요. -->

- **테스트 방법**:
  1. 플레이리스트 상세 조회 API 호출 시 `createdByMe`와 `liked` 필드가 반환되는지 확인.
  2. 요청한 사용자와 플레이리스트 생성자 ID 비교 결과를 `createdByMe`로 확인.
  3. 요청 사용자의 좋아요 여부를 `liked`로 확인.
- **참고 자료**:[API 문서](http://43.202.172.0:8080/api-docs#/)
