### PR TITLE
[Feat] 플레이리스트 수정 API 확장 및 동영상 순서 정렬 개선

### DIFF
--- a/src/playlist/dto/update-playlist.dto.ts
+++ b/src/playlist/dto/update-playlist.dto.ts
@@ -1,5 +1,83 @@
-import { IsString, IsOptional, IsArray, ArrayNotEmpty } from 'class-validator';
+import { IsString, IsOptional, IsArray, ArrayNotEmpty, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
+
+export class VideoDto {
+  @ApiProperty({
+    example: 'abc123',
+    description: '유튜브 동영상 ID',
+  })
+  @IsString()
+  youtubeId: string;
+
+  @ApiProperty({
+    example: 'New Song Title',
+    description: '동영상 제목',
+  })
+  @IsString()
+  title: string;
+
+  @ApiProperty({
+    example: 'https://img.youtube.com/vi/jWQx2f-CErU/0.jpg',
+    description: '동영상 썸네일 URL',
+  })
+  @IsString()
+  thumbnailUrl: string;
+
+  @ApiProperty({
+    example: 'Channel Name',
+    description: '채널 이름',
+  })
+  @IsString()
+  channelName: string;
+
+  @ApiProperty({
+    example: 180,
+    description: '동영상 길이(초 단위)',
+  })
+  @IsOptional()
+  duration?: number;
+
+  @ApiProperty({
+    example: 1,
+    description: '동영상 순서',
+  })
+  @IsOptional()
+  order?: number;
+}
+
+export class VideosDto {
+  @ApiProperty({
+    description: '삭제할 동영상 ID 목록',
+    example: [101, 102],
+    type: [Number],
+    required: false,
+  })
+  @IsArray()
+  @IsOptional()
+  toRemove?: number[];
+
+  @ApiProperty({
+    description: '추가할 동영상 정보 목록',
+    example: [
+      {
+        youtubeId: 'abc123',
+        title: 'New Song Title',
+        thumbnailUrl: 'https://img.youtube.com/vi/jWQx2f-CErU/0.jpg',
+        channelName: 'Channel Name',
+        duration: 180,
+        order: 2,
+      },
+    ],
+    type: [VideoDto],
+    required: false,
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => VideoDto)
+  @IsOptional()
+  toAdd?: VideoDto[];
+}
 
 export class UpdatePlaylistDto {
   @ApiProperty({
@@ -12,7 +90,7 @@ export class UpdatePlaylistDto {
   title?: string;
 
   @ApiProperty({
-    example: '업데이트된 플레이리스트 설명',
+    example: 'Updated description',
     description: '플레이리스트 설명',
     required: false,
   })
@@ -21,13 +99,22 @@ export class UpdatePlaylistDto {
   description?: string;
 
   @ApiProperty({
-    example: ['업데이트', '새로운 태그'],
+    example: ['Pop', 'K-Pop'],
     description: '플레이리스트 태그 목록',
     required: false,
   })
   @IsArray()
-  @ArrayNotEmpty()
   @IsString({ each: true })
   @IsOptional()
   tags?: string[];
+
+  @ApiProperty({
+    description: '플레이리스트 수정 시 동영상 추가/삭제 정보',
+    type: VideosDto,
+    required: false,
+  })
+  @ValidateNested()
+  @Type(() => VideosDto)
+  @IsOptional()
+  videos?: VideosDto;
 }

--- a/src/playlist/playlist.controller.ts
+++ b/src/playlist/playlist.controller.ts
@@ -21,7 +21,7 @@ import { AddVideoDto } from './dto/add-video.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { Request } from 'express';
 import { Public } from 'src/auth/auth.decorator';
-import { ApiOperation, ApiResponse, ApiQuery, ApiBearerAuth } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiQuery, ApiBearerAuth, ApiBody  } from '@nestjs/swagger';
 
 @ApiBearerAuth()
 @Controller('/playlists')
@@ -226,6 +226,68 @@ export class PlaylistController {
                 곡 추가(toAdd): 추가할 동영상 정보를 제공 (youtubeId, title, thumbnailUrl 등).<br>
                 곡 삭제(toRemove): 삭제할 동영상의 ID 목록을 제공.<br>
                 만약 동영상 추가와 삭제 정보가 모두 비어 있다면 태그와 제목, 설명만 수정됩니다.` })
+  @ApiBody({
+  description: '플레이리스트 수정 요청 데이터',
+  schema: {
+    type: 'object',
+    properties: {
+      title: {
+        type: 'string',
+        example: 'Updated Playlist Title',
+        description: '플레이리스트 제목',
+      },
+      description: {
+        type: 'string',
+        example: 'Updated description',
+        description: '플레이리스트 설명',
+      },
+      tags: {
+        type: 'array',
+        items: { type: 'string' },
+        example: ['Pop', 'K-Pop'],
+        description: '플레이리스트 태그 목록',
+      },
+      videos: {
+        type: 'object',
+        properties: {
+          toRemove: {
+            type: 'array',
+            items: { type: 'number' },
+            description: '삭제할 비디오 ID 목록',
+            example: [90, 91],
+          },
+          toAdd: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                youtubeId: { type: 'string', example: 'abc123' },
+                title: { type: 'string', example: 'New Song Title' },
+                thumbnailUrl: { type: 'string', example: 'https://img.youtube.com/vi/abc123/0.jpg' },
+                channelName: { type: 'string', example: 'Channel Name' },
+                duration: { type: 'number', example: 180 },
+                order: { type: 'number', example: 2 },
+              },
+            },
+            description: '추가할 비디오 정보 목록',
+            example: [
+              {
+                youtubeId: 'abc123',
+                title: 'New Song Title',
+                thumbnailUrl: 'https://img.youtube.com/vi/abc123/0.jpg',
+                channelName: 'Channel Name',
+                duration: 180,
+                order: 2,
+              },
+            ],
+          },
+        },
+        description: '동영상 삭제/추가 정보',
+      },
+    },
+    required: [],
+  },
+})
   @ApiResponse({
     status: 200,
     description: '플레이리스트 수정 성공',

--- a/src/playlist/playlist.controller.ts
+++ b/src/playlist/playlist.controller.ts
@@ -219,7 +219,13 @@ export class PlaylistController {
 
   @Patch(':id')
   @UseGuards(JwtAuthGuard)
-  @ApiOperation({ summary: '플레이리스트 수정', description: '지정된 ID의 플레이리스트를 수정합니다.' })
+  @ApiOperation({
+    summary: '플레이리스트 수정',
+  description: `지정된 ID의 플레이리스트를 수정합니다.<br>
+                곡 추가/삭제는 선택적으로 제공할 수 있습니다.<br>
+                곡 추가(toAdd): 추가할 동영상 정보를 제공 (youtubeId, title, thumbnailUrl 등).<br>
+                곡 삭제(toRemove): 삭제할 동영상의 ID 목록을 제공.<br>
+                만약 동영상 추가와 삭제 정보가 모두 비어 있다면 태그와 제목, 설명만 수정됩니다.` })
   @ApiResponse({
     status: 200,
     description: '플레이리스트 수정 성공',
@@ -227,41 +233,62 @@ export class PlaylistController {
       example: {
         id: 1,
         title: 'Updated Playlist Title',
-        description: '업데이트된 설명',
-        tags: ['업데이트', '새로운 태그'],
+        description: 'Updated description',
+        tags: ['Pop', 'K-Pop'],
+        videos: [
+          {
+            id: 101,
+            youtubeId: 'abc123',
+            title: 'Updated Song Title',
+            channelName: 'Channel Name',
+            thumbnailUrl: 'https://img.youtube.com/vi/abc123/0.jpg',
+            duration: 180,
+            order: 1,
+          },
+        ],
         message: '플레이리스트 수정 성공',
       },
     },
   })
   @ApiResponse({
     status: 404,
-    description: '존재하지 않는 플레이리스트',
-    schema: { example: { message: '플레이리스트를 찾을 수 없습니다.' } },
+    description: '존재하지 않는 플레이리스트 또는 비디오',
+    schema: { example: { message: '플레이리스트 또는 비디오를 찾을 수 없습니다.' } },
   })
   @ApiResponse({
     status: 401,
     description: '인증 오류',
-    schema: { example: { message: '인증이 필요합니다.' } },
+    schema: { example: { message: '수정 권한이 없습니다.' } },
   })
   @ApiResponse({
     status: 400,
     description: '잘못된 입력 데이터',
     schema: { example: { message: '입력값이 유효하지 않습니다.' } },
-  })  
+  })
   async updatePlaylist(
     @Param('id') id: string,
     @Body() dto: UpdatePlaylistDto,
     @Req() req: Request,
   ): Promise<any> {
     const updatedPlaylist = await this.playlistService.updatePlaylist(parseInt(id, 10), req.user?.userId, dto);
+    
     return {
       id: updatedPlaylist.id,
       title: updatedPlaylist.title,
       description: updatedPlaylist.description,
-      tags: updatedPlaylist.tags, // 안전하게 반환
+      tags: updatedPlaylist.tags,
+      videos: updatedPlaylist.videos.map((video) => ({
+        id: video.id,
+        youtubeId: video.youtubeId,
+        title: video.title,
+        channelName: video.channelName,
+        thumbnailUrl: video.thumbnailUrl,
+        duration: video.duration,
+        order: video.order,
+      })),
       message: '플레이리스트 수정 성공',
     };
-  }  
+  }
   
 
   @Delete(':id')

--- a/src/playlist/playlist.module.ts
+++ b/src/playlist/playlist.module.ts
@@ -3,10 +3,11 @@ import { PlaylistController } from './playlist.controller';
 import { PlaylistService } from './playlist.service';
 import { PrismaModule } from '../prisma/prisma.module';
 import { AuthModule } from '../auth/auth.module';
+import { VideoModule } from '../video/video.module';
 import { VideoService } from '../video/video.service';
 
 @Module({
-  imports: [PrismaModule, AuthModule],
+  imports: [PrismaModule, AuthModule, VideoModule],
   controllers: [PlaylistController],
   providers: [PlaylistService, VideoService],
 })

--- a/src/video/video.module.ts
+++ b/src/video/video.module.ts
@@ -8,5 +8,6 @@ import { AuthModule } from '../auth/auth.module';
   imports: [PrismaModule, AuthModule],
   controllers: [VideoController],
   providers: [VideoService],
+  exports: [VideoService], // VideoService를 외부로 노출
 })
 export class VideoModule {}


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)

- ✨ 주요 기능:
  - [x] **플레이리스트 수정 API**: 삭제 및 추가 동작 처리 로직 추가, 동영상 순서 정렬 로직 개선
  - [x] **플레이리스트 모듈**: 비디오 모듈 의존성 추가
  - [x] **플레이리스트 수정 서비스**: `toRemove` 및 `toAdd` 처리 로직 추가 및 테스트 케이스 기반 정렬 처리
  - [x] **DTO 수정**: `update-playlist.dto.ts`에 비디오 삭제/추가 처리 옵션 추가
  - [x] **비디오 모듈 설정**: 비디오 모듈에서 플레이리스트 서비스 의존성 반영

---

# 🤔 논의가 필요한 사항 (Points to discuss)

- [ ] 비디오 순서 정렬 로직 최적화 및 성능 테스트 여부
- [ ] 추가적으로 필요한 API 또는 수정 사항

---

# 🖼️ 결과 이미지 (Screenshots)

<!-- 변경된 결과를 확인할 수 있는 스크린샷을 첨부해주세요. -->
| **`toRemove`만 포함 :  삭제 후 남은 동영상이 `videoId` 기준으로 정렬.**  | **`toAdd`만 포함 : 추가된 동영상이 기존 동영상 `videoId` 기준으로 정렬.**    |**둘 다 포함 : 삭제 후 추가된 동영상 포함해 전체 순서 재정렬.**    |**`toRemove` 및 `toAdd` 모두 비어 있음 : API 호출 성공 및 변경 없음.**    |
|-----------------------------|-----------------------------|-----------------------------|-----------------------------|
| ![image](https://github.com/user-attachments/assets/7d74fad7-7dc4-492b-9d1e-81cf476df98e)  | ![image](https://github.com/user-attachments/assets/1422cdd1-debd-428b-8e27-a073ea4d11a0)   | ![image](https://github.com/user-attachments/assets/dd8ea906-dad7-42e3-9c4d-cb7370a45806)   | ![image](https://github.com/user-attachments/assets/5a37fd0f-a09c-4e5d-8358-847e7f4bcbe2)   |

---

# 🛠️ 추가 수정 필요 사항 (Additional fixes required)

- [ ] 비디오 삭제/추가와 순서 변경이 다중 사용자 환경에서 충돌하지 않도록 동시성 처리 검토
- [ ] Swagger 문서에 모든 테스트 케이스 추가 ->  NestJS에서 기본적으로 Swagger를 통해 드롭다운 메뉴를 제공을 하지 않아서
테스트 케이스 4가지를 추가하지 못했습니다.

---

# 📝 참고 사항 (Additional notes)

- **테스트 방법**:
  1. `toRemove`만 포함된 요청을 전송해 삭제 확인
  2. `toAdd`만 포함된 요청을 전송해 추가 확인
  3. `toRemove`와 `toAdd`를 모두 포함한 요청을 테스트
  4. 빈 `videos` 객체를 포함하여 처리 로직 확인
### ✅테스트 케이스

1. **Case 1: `toRemove`만 포함 :**  삭제 후 남은 동영상이 `videoId` 기준으로 정렬.
    
    ```json
    {
        "title": "Updated Playlist Title",
        "description": "Updated description",
        "tags": ["Pop", "K-Pop"],
        "videos": {
            "toRemove": [90, 91]
        }
    }
    ```
    
2. **Case 2: `toAdd`만 포함 :** 추가된 동영상이 기존 동영상 `videoId` 기준으로 정렬.
    
    ```json
    {
        "title": "Updated Playlist Title",
        "description": "Updated description",
        "tags": ["Pop", "K-Pop"],
        "videos": {
            "toAdd": [
                {
                    "youtubeId": "abc123",
                    "title": "New Song Title",
                    "thumbnailUrl": "https://img.youtube.com/vi/abc123/0.jpg",
                    "channelName": "Channel Name",
                    "duration": 180,
                    "order": 2
                }
            ]
        }
    }
    ```
    
3. **Case 3: 둘 다 포함 :** 삭제 후 추가된 동영상 포함해 전체 순서 재정렬.
    
    ```json
    {
        "title": "Updated Playlist Title",
        "description": "Updated description",
        "tags": ["Pop", "K-Pop"],
        "videos": {
            "toRemove": [90, 91],
            "toAdd": [
                {
                    "youtubeId": "abc123",
                    "title": "New Song Title",
                    "thumbnailUrl": "https://img.youtube.com/vi/abc123/0.jpg",
                    "channelName": "Channel Name",
                    "duration": 180,
                    "order": 2
                }
            ]
        }
    }
    ```
    
4. **Case 4: `toRemove` 및 `toAdd` 모두 비어 있음 :** API 호출 성공 및 변경 없음.
    
    ```json
    {
        "title": "Updated Playlist Title",
        "description": "Updated description",
        "tags": ["Pop", "K-Pop"],
        "videos": {}
    }
    ```
