### PR TITLE
[Feat] 플레이리스트 생성 시 최소 응답 데이터 반환 및 로직 최적화

### DIFF
--- a/src/playlist/dto/create-playlist.dto.ts
+++ b/src/playlist/dto/create-playlist.dto.ts
@@ -1,5 +1,7 @@
-import { IsString, IsOptional, IsArray, ValidateNested } from 'class-validator';
+import { IsString, IsOptional, IsArray, IsNotEmpty, ValidateNested } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { AddVideoDto } from './add-video.dto'
 
 
 export class CreatePlaylistDto {
@@ -8,6 +10,7 @@ export class CreatePlaylistDto {
     description: '플레이리스트 제목',
   })
   @IsString()
+  @IsNotEmpty()
   title: string;
 
   @ApiProperty({
@@ -28,4 +31,10 @@ export class CreatePlaylistDto {
   @IsString({ each: true })
   @IsOptional()
   tags?: string[];
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AddVideoDto)
+  @IsOptional()
+  videos?: AddVideoDto[]; // 추가된 필드
 }

--- a/src/playlist/playlist.controller.ts
+++ b/src/playlist/playlist.controller.ts
@@ -184,17 +184,34 @@ export class PlaylistController {
   @UseGuards(JwtAuthGuard)
   @ApiOperation({
     summary: '플레이리스트 생성',
-    description: `새로운 플레이리스트를 생성합니다.`,
+    description: `새로운 플레이리스트를 생성합니다. 플레이리스트 생성 시 동영상을 함께 추가할 수 있습니다.`,
+  })
+  @ApiBody({
+    description: '새로운 플레이리스트 생성 요청 데이터',
+    schema: {
+      example: {
+        title: 'My Favorite Songs',
+        description: '즐겨듣는 노래 모음',
+        tags: ['Pop', 'K-Pop'],
+        videos: [
+          {
+            youtubeId: 'abc123',
+            title: '노래 제목',
+            thumbnailUrl: 'https://img.youtube.com/vi/abc123/0.jpg',
+            channelName: '채널 이름',
+            duration: 180,
+            order: 1,
+          },
+        ],
+      },
+    },
   })
   @ApiResponse({
     status: 201,
     description: '플레이리스트 생성 성공',
     schema: {
       example: {
-        id: 1,
-        title: 'My Favorite Songs',
-        description: '즐겨듣는 노래 모음',
-        tags: ['Pop', 'K-Pop'],
+        playlistId: 1,
         message: '플레이리스트 생성 성공',
       },
     },
@@ -202,7 +219,7 @@ export class PlaylistController {
   @ApiResponse({
     status: 400,
     description: '필수 데이터 누락',
-    schema: { example: { message: '제목과 태그, 첫번째 비디오 값은 필수입니다.' } },
+    schema: { example: { message: '제목, 태그 또는 비디오 데이터가 누락되었습니다.' } },
   })
   @ApiResponse({
     status: 401,
@@ -211,8 +228,15 @@ export class PlaylistController {
   })
   async createPlaylist(@Body() dto: CreatePlaylistDto, @Req() req): Promise<any> {
     const userId = req.user?.userId;
+  
+    // 서비스 로직 호출
     const playlist = await this.playlistService.createPlaylist(dto, userId);
-    return playlist;
+  
+    // 반환 데이터 간소화
+    return {
+      playlistId: playlist.id,
+      message: '플레이리스트 생성 성공',
+    };
   }
   
   


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)

<!-- 구현한 기능이나 변경 사항을 간략히 요약해주세요. -->
- ✨ 주요 기능:
  - 플레이리스트 생성 시 응답 데이터를 간소화하여 `playlistId`와 `message`만 반환하도록 수정.
  - `CreatePlaylistDto`를 수정하여 동영상 배열(videos)을 포함한 요청 데이터 구조를 지원.
  - `PlaylistService`에서 불필요한 데이터 반환을 제거하고 로직 최적화.

---

# 🤔 논의가 필요한 사항 (Points to discuss)

<!-- 논의가 필요한 사항, 개선해야 할 부분을 작성해주세요. -->
- [ ] 플레이리스트 생성 시 동영상 추가가 제대로 처리되지 않을 경우의 예외 처리 강화 필요.
- [ ] 현재 응답 구조 간소화와 팀 내 요구 사항 충돌 여부.

---

# 🖼️ 결과 이미지 (Screenshots)

<!-- 변경된 결과를 확인할 수 있는 스크린샷을 첨부해주세요. -->
| **수정 전**                  | **수정 후**                   |
|-----------------------------|-----------------------------|
| ![image](https://github.com/user-attachments/assets/5ec8de17-142a-4b1a-9795-20653b3459cd)    | ![image](https://github.com/user-attachments/assets/37928d44-3535-47a6-b095-584bf31e0ace)    |

---

# 🛠️ 추가 수정 필요 사항 (Additional fixes required)

<!-- PR에 포함되지 않았지만, 추가적으로 해야 할 작업이 있다면 작성해주세요. -->
- [ ] 프론트엔드와 협업하여 요청 데이터 및 응답 데이터 확인.

---

# 📝 참고 사항 (Additional notes)

<!-- 테스트 방법, 관련 이슈, 참고 문서 등을 작성해주세요. -->
- **테스트 방법**:
  1. `/api/playlists` 엔드포인트 호출.
  3. 동영상 배열(비우기 가능)과 함께 플레이리스트 생성 요청.
